### PR TITLE
Implement multi-stage pattern to reduce docker image from ~800mb to 7mb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,31 @@
-FROM golang:1.9.3
+FROM golang:alpine as builder
 
-RUN mkdir -p /go/src/baton
-WORKDIR /go/src/baton
+# get deps ca-certs and git
+RUN apk update && apk add git && apk add ca-certificates
+ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep
+RUN chmod +x /usr/bin/dep
 
-COPY . .
+# create baton user
+RUN adduser -D -g '' batonuser
 
-RUN go install
+# copy src and set working directory
+COPY . $GOPATH/src/baton/
+WORKDIR $GOPATH/src/baton/
 
-ENTRYPOINT ["baton"]
+# run dep 
+RUN dep ensure --vendor-only
+
+# disable support for c system libs, for use with scratch
+ENV CGO_ENABLED 0
+ENV GOOS linux
+ENV GOARCH amd64
+
+# build and test our binary
+RUN go test -v
+RUN go build -a -installsuffix cgo -o /go/bin/baton
+
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /go/bin/baton /go/bin/baton
+ENTRYPOINT ["/go/bin/baton"]


### PR DESCRIPTION
Greetings!

I've used this for a personal project on a fairly low powered device, so I modified the Dockerfile a bit to reduce the end image footprint from 750mb to about 7mb. I found it helpful so here you go :smile: 

While I was at it, I added the same steps in the Travis file to the build phase in the Dockerfile. I see that you deliver binaries for all operating systems which is likely why this wasn't added in the first place, so I threw that in.
 
I also switched from `go get` to `dep` to stay standard. 

```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
baton               amex                278b7ed271fb        3 minutes ago      750MB
baton               tony                5ce105896748        2 minutes ago      7.05MB
```

Humming along. 
```
$ docker-compose up
Starting baton_server_1 ... 
Starting baton_server_1 ... done
Recreating baton_baton_1 ... 
Recreating baton_baton_1 ... done
Attaching to baton_server_1, baton_baton_1
baton_1   | Configuring to send GET requests to: http://server
baton_1   | Generating the requests...
baton_1   | Finished generating the requests
baton_1   | Sending the requests to the server...
server_1  | 172.18.0.3 - - [02/Nov/2018:15:30:13 +0000] "GET / HTTP/1.1" 200 612 "-" "fasthttp" "-"
server_1  | 172.18.0.3 - - [02/Nov/2018:15:30:13 +0000] "GET / HTTP/1.1" 200 612 "-" "fasthttp" "-"
server_1  | 172.18.0.3 - - [02/Nov/2018:15:30:13 +0000] "GET / HTTP/1.1" 200 612 "-" "fasthttp" "-"
server_1  | 172.18.0.3 - - [02/Nov/2018:15:30:13 +0000] "GET / HTTP/1.1" 200 612 "-" "fasthttp" "-"
server_1  | 172.18.0.3 - - [02/Nov/2018:15:30:13 +0000] "GET / HTTP/1.1" 200 612 "-" "fasthttp" "-"
server_1  | 172.18.0.3 - - [02/Nov/2018:15:30:13 +0000] "GET / HTTP/1.1" 200 612 "-" "fasthttp" "-"
server_1  | 172.18.0.3 - - [02/Nov/2018:15:30:13 +0000] "GET / HTTP/1.1" 200 612 "-" "fasthttp" "-"
server_1  | 172.18.0.3 - - [02/Nov/2018:15:30:13 +0000] "GET / HTTP/1.1" 200 612 "-" "fasthttp" "-"
server_1  | 172.18.0.3 - - [02/Nov/2018:15:30:13 +0000] "GET / HTTP/1.1" 200 612 "-" "fasthttp" "-"
server_1  | 172.18.0.3 - - [02/Nov/2018:15:30:13 +0000] "GET / HTTP/1.1" 200 612 "-" "fasthttp" "-"
baton_1   | Finished sending the requests
baton_1   | Processing the results...
baton_1   | 
baton_1   | =========================== Results ========================================
baton_1   | 
baton_1   | Total requests:                                    10
baton_1   | Time taken to complete requests:           1.448121ms
baton_1   | Requests per second:                             6906
baton_1   | Max response time (ms):                             0
baton_1   | Min response time (ms):                             0
baton_1   | Avg response time (ms):                          0.00
baton_1   | 
baton_1   | ========= Percentage of responses by status code ==========================
baton_1   | 
baton_1   | Number of connection errors:                        0
baton_1   | Number of 1xx responses:                            0
baton_1   | Number of 2xx responses:                           10
baton_1   | Number of 3xx responses:                            0
baton_1   | Number of 4xx responses:                            0
baton_1   | Number of 5xx responses:                            0
baton_1   | 
baton_1   | ===========================================================================
baton_baton_1 exited with code 0
```